### PR TITLE
Parse count modifier as integer

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33,7 +33,10 @@ function src_default(Alpine) {
     let respectWordBoundary = false;
     const countIndex = modifiers.indexOf('count');
     if (countIndex !== -1 && countIndex + 1 < modifiers.length) {
-      count = modifiers[countIndex + 1];
+      const parsedCount = parseInt(modifiers[countIndex + 1], 10);
+      if (!isNaN(parsedCount)) {
+        count = parsedCount;
+      }
     }
     if (modifiers.includes('nodots')) {
       showDots = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,10 @@ export default function (Alpine) {
 
     const countIndex = modifiers.indexOf('count');
     if (countIndex !== -1 && countIndex + 1 < modifiers.length) {
-      count = modifiers[countIndex + 1];
+      const parsedCount = parseInt(modifiers[countIndex + 1], 10);
+      if (!isNaN(parsedCount)) {
+        count = parsedCount;
+      }
     }
 
     if (modifiers.includes('nodots')) {


### PR DESCRIPTION
## Summary
- ensure `x-trim` count modifier is parsed as an integer
- bundle updates

## Testing
- `npm run buildes`
- `npm run check-format`


------
https://chatgpt.com/codex/tasks/task_e_68ab14e7e370832996057b8df8f9e79e